### PR TITLE
[docs] Add guide to copy file source connector to container

### DIFF
--- a/site2/docs/io-file-source.md
+++ b/site2/docs/io-file-source.md
@@ -105,7 +105,13 @@ Here is an example of using the File source connecter.
     $ curl -O https://mirrors.tuna.tsinghua.edu.cn/apache/pulsar/pulsar-{version}/connectors/pulsar-io-file-{version}.nar
     ```
 
-6. Start the File source connector.
+6. Copt the File source connector to the container. 
+
+    ```bash
+    $ docker cp pulsar-io-file-{version}.nar pulsar-standalone:/pulsar/
+    ```
+
+7. Start the File source connector.
 
     ```bash
     $ docker exec -it pulsar-standalone /bin/bash
@@ -117,13 +123,13 @@ Here is an example of using the File source connecter.
     --source-config-file /pulsar/file-connector.yaml
     ```
 
-7. Start a consumer.
+8. Start a consumer.
 
     ```bash
     ./bin/pulsar-client consume -s file-test -n 0 pulsar-file-test
     ```
 
-8. Write the message to the file _test.txt_.
+9. Write the message to the file _test.txt_.
    
     ```bash
     echo "hello world!" > /opt/test.txt


### PR DESCRIPTION
Added instruction to copy file source connector into docker image. 
Adjusted numbers accordingly

### Motivation

* I am testing out the file source connector and it would not run without this command

### Modifications

I have adjusted the guide to tell the user to copy the connector to the docker instance

### Verifying this change

This change is already covered by existing tests


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API:  no
  - The schema:  no 
  - The default values of configurations:  no
  - The wire protocol:  no
  - The rest endpoints:  no
  - The admin cli options: no
  - Anything that affects deployment: no 

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `doc` 